### PR TITLE
chore: update nokogiri 1.16.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-xml_editor (0.5.0)
-      nokogiri (~> 1.16.2)
+    fastlane-plugin-xml_editor (0.6.0)
+      nokogiri (~> 1.16.5)
       plist (~> 3.3.0)
 
 GEM
@@ -169,7 +169,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.16.2-arm64-darwin)
+    nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
     optparse (0.1.1)
     os (1.1.4)

--- a/fastlane-plugin-xml_editor.gemspec
+++ b/fastlane-plugin-xml_editor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   spec.add_dependency 'plist', '~> 3.3.0'
-  spec.add_dependency 'nokogiri', '~> 1.16.2'
+  spec.add_dependency 'nokogiri', '~> 1.16.5'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/lib/fastlane/plugin/xml_editor/version.rb
+++ b/lib/fastlane/plugin/xml_editor/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module XmlEditor
-    VERSION = "0.5.0"
+    VERSION = "0.6.0"
   end
 end


### PR DESCRIPTION
- updates nokogiri to 1.16.5 because of vulnerability